### PR TITLE
Implement ProjectMembership management

### DIFF
--- a/src/main/java/acme/features/manager/membership/ManagerProjectMembershipController.java
+++ b/src/main/java/acme/features/manager/membership/ManagerProjectMembershipController.java
@@ -1,0 +1,24 @@
+
+package acme.features.manager.membership;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+
+import acme.client.controllers.AbstractController;
+import acme.entities.project.ProjectMembership;
+import acme.realms.Manager;
+
+@Controller
+public class ManagerProjectMembershipController extends AbstractController<Manager, ProjectMembership> {
+
+	@PostConstruct
+	protected void initialise() {
+		super.setMediaType(MediaType.TEXT_HTML);
+
+		super.addBasicCommand("list", ManagerProjectMembershipListService.class);
+		super.addBasicCommand("show", ManagerProjectMembershipShowService.class);
+		super.addBasicCommand("create", ManagerProjectMembershipCreateService.class);
+	}
+}

--- a/src/main/java/acme/features/manager/membership/ManagerProjectMembershipCreateService.java
+++ b/src/main/java/acme/features/manager/membership/ManagerProjectMembershipCreateService.java
@@ -1,0 +1,128 @@
+
+package acme.features.manager.membership;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractService;
+import acme.entities.project.Project;
+import acme.entities.project.ProjectMembership;
+import acme.realms.Fundraiser;
+import acme.realms.Inventor;
+import acme.realms.Manager;
+import acme.realms.Spokesperson;
+
+@Service
+public class ManagerProjectMembershipCreateService extends AbstractService<Manager, ProjectMembership> {
+
+	@Autowired
+	private ManagerProjectMembershipRepository	repository;
+
+	private ProjectMembership					membership;
+
+
+	@Override
+	public void load() {
+		int projectId;
+		Project project;
+
+		projectId = super.getRequest().getData("projectId", int.class);
+		project = this.repository.findProjectById(projectId);
+
+		this.membership = new ProjectMembership();
+		this.membership.setProject(project);
+	}
+
+	@Override
+	public void authorise() {
+		boolean status;
+
+		status = this.membership.getProject() != null && this.membership.getProject().isDraftMode() && this.membership.getProject().getManager().isPrincipal();
+
+		super.setAuthorised(status);
+	}
+
+	@Override
+	public void bind() {
+		int inventorId;
+		int spokespersonId;
+		int fundraiserId;
+
+		inventorId = super.getRequest().getData("inventor", int.class);
+		spokespersonId = super.getRequest().getData("spokesperson", int.class);
+		fundraiserId = super.getRequest().getData("fundraiser", int.class);
+
+		if (inventorId != 0) {
+			Inventor inventor = this.repository.findInventorById(inventorId);
+			this.membership.setInventor(inventor);
+		}
+		if (spokespersonId != 0) {
+			Spokesperson spokesperson = this.repository.findSpokespersonById(spokespersonId);
+			this.membership.setSpokesperson(spokesperson);
+		}
+		if (fundraiserId != 0) {
+			Fundraiser fundraiser = this.repository.findFundraiserById(fundraiserId);
+			this.membership.setFundraiser(fundraiser);
+		}
+	}
+
+	@Override
+	public void validate() {
+		int rolesSelected;
+
+		rolesSelected = (this.membership.getInventor() != null ? 1 : 0) //
+			+ (this.membership.getSpokesperson() != null ? 1 : 0) //
+			+ (this.membership.getFundraiser() != null ? 1 : 0);
+
+		super.state(rolesSelected > 0, "*", "manager.project-membership.form.error.no-member");
+		super.state(rolesSelected <= 1, "*", "manager.project-membership.form.error.multiple-roles");
+
+		// Check for duplicate membership only when exactly one role is selected
+		if (rolesSelected == 1) {
+			if (this.membership.getInventor() != null) {
+				ProjectMembership existing = this.repository.findMembershipByProjectAndInventor(this.membership.getProject().getId(), this.membership.getInventor().getId());
+				super.state(existing == null, "inventor", "manager.project-membership.form.error.duplicate");
+			}
+			if (this.membership.getSpokesperson() != null) {
+				ProjectMembership existing = this.repository.findMembershipByProjectAndSpokesperson(this.membership.getProject().getId(), this.membership.getSpokesperson().getId());
+				super.state(existing == null, "spokesperson", "manager.project-membership.form.error.duplicate");
+			}
+			if (this.membership.getFundraiser() != null) {
+				ProjectMembership existing = this.repository.findMembershipByProjectAndFundraiser(this.membership.getProject().getId(), this.membership.getFundraiser().getId());
+				super.state(existing == null, "fundraiser", "manager.project-membership.form.error.duplicate");
+			}
+		}
+	}
+
+	@Override
+	public void execute() {
+		this.repository.save(this.membership);
+	}
+
+	@Override
+	public void unbind() {
+		Collection<Inventor> inventors;
+		Collection<Spokesperson> spokespeople;
+		Collection<Fundraiser> fundraisers;
+		SelectChoices inventorChoices;
+		SelectChoices spokespersonChoices;
+		SelectChoices fundraiserChoices;
+
+		inventors = this.repository.findAllInventors();
+		spokespeople = this.repository.findAllSpokespeople();
+		fundraisers = this.repository.findAllFundraisers();
+
+		inventorChoices = SelectChoices.from(inventors, "userAccount.identity.fullName", this.membership.getInventor());
+		spokespersonChoices = SelectChoices.from(spokespeople, "userAccount.identity.fullName", this.membership.getSpokesperson());
+		fundraiserChoices = SelectChoices.from(fundraisers, "userAccount.identity.fullName", this.membership.getFundraiser());
+
+		super.unbindObject(this.membership);
+		super.getResponse().addGlobal("inventorChoices", inventorChoices);
+		super.getResponse().addGlobal("spokespersonChoices", spokespersonChoices);
+		super.getResponse().addGlobal("fundraiserChoices", fundraiserChoices);
+		super.getResponse().addGlobal("projectId", this.membership.getProject().getId());
+	}
+}

--- a/src/main/java/acme/features/manager/membership/ManagerProjectMembershipListService.java
+++ b/src/main/java/acme/features/manager/membership/ManagerProjectMembershipListService.java
@@ -1,0 +1,58 @@
+
+package acme.features.manager.membership;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import acme.client.services.AbstractService;
+import acme.entities.project.Project;
+import acme.entities.project.ProjectMembership;
+import acme.realms.Manager;
+
+@Service
+public class ManagerProjectMembershipListService extends AbstractService<Manager, ProjectMembership> {
+
+	@Autowired
+	private ManagerProjectMembershipRepository	repository;
+
+	private Collection<ProjectMembership>		memberships;
+
+	private Project								project;
+
+
+	@Override
+	public void authorise() {
+		boolean status;
+		int projectId;
+
+		projectId = super.getRequest().getData("projectId", int.class);
+		this.project = this.repository.findProjectById(projectId);
+		status = this.project != null && this.project.getManager().isPrincipal();
+
+		super.setAuthorised(status);
+	}
+
+	@Override
+	public void load() {
+		int projectId;
+
+		projectId = super.getRequest().getData("projectId", int.class);
+		this.project = this.repository.findProjectById(projectId);
+		this.memberships = this.repository.findMembershipsByProjectId(projectId);
+	}
+
+	@Override
+	public void unbind() {
+		boolean showCreate;
+
+		// memberName and memberType are @Transient computed getters on ProjectMembership
+		showCreate = this.project.isDraftMode() && this.project.getManager().isPrincipal();
+
+		super.unbindObjects(this.memberships, "memberName", "memberType");
+		super.getResponse().addGlobal("showCreate", showCreate);
+		super.getResponse().addGlobal("projectId", this.project.getId());
+	}
+
+}

--- a/src/main/java/acme/features/manager/membership/ManagerProjectMembershipRepository.java
+++ b/src/main/java/acme/features/manager/membership/ManagerProjectMembershipRepository.java
@@ -1,0 +1,54 @@
+
+package acme.features.manager.membership;
+
+import java.util.Collection;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import acme.client.repositories.AbstractRepository;
+import acme.entities.project.Project;
+import acme.entities.project.ProjectMembership;
+import acme.realms.Fundraiser;
+import acme.realms.Inventor;
+import acme.realms.Spokesperson;
+
+@Repository
+public interface ManagerProjectMembershipRepository extends AbstractRepository {
+
+	@Query("select pm from ProjectMembership pm where pm.id = :id")
+	ProjectMembership findMembershipById(int id);
+
+	@Query("select pm from ProjectMembership pm where pm.project.id = :projectId")
+	Collection<ProjectMembership> findMembershipsByProjectId(int projectId);
+
+	@Query("select p from Project p where p.id = :id")
+	Project findProjectById(int id);
+
+	@Query("select i from Inventor i where i.id = :id")
+	Inventor findInventorById(int id);
+
+	@Query("select s from Spokesperson s where s.id = :id")
+	Spokesperson findSpokespersonById(int id);
+
+	@Query("select f from Fundraiser f where f.id = :id")
+	Fundraiser findFundraiserById(int id);
+
+	@Query("select i from Inventor i")
+	Collection<Inventor> findAllInventors();
+
+	@Query("select s from Spokesperson s")
+	Collection<Spokesperson> findAllSpokespeople();
+
+	@Query("select f from Fundraiser f")
+	Collection<Fundraiser> findAllFundraisers();
+
+	@Query("select pm from ProjectMembership pm where pm.project.id = :projectId and pm.inventor.id = :inventorId")
+	ProjectMembership findMembershipByProjectAndInventor(int projectId, int inventorId);
+
+	@Query("select pm from ProjectMembership pm where pm.project.id = :projectId and pm.spokesperson.id = :spokespersonId")
+	ProjectMembership findMembershipByProjectAndSpokesperson(int projectId, int spokespersonId);
+
+	@Query("select pm from ProjectMembership pm where pm.project.id = :projectId and pm.fundraiser.id = :fundraiserId")
+	ProjectMembership findMembershipByProjectAndFundraiser(int projectId, int fundraiserId);
+}

--- a/src/main/java/acme/features/manager/membership/ManagerProjectMembershipShowService.java
+++ b/src/main/java/acme/features/manager/membership/ManagerProjectMembershipShowService.java
@@ -1,0 +1,43 @@
+
+package acme.features.manager.membership;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import acme.client.services.AbstractService;
+import acme.entities.project.ProjectMembership;
+import acme.realms.Manager;
+
+@Service
+public class ManagerProjectMembershipShowService extends AbstractService<Manager, ProjectMembership> {
+
+	@Autowired
+	private ManagerProjectMembershipRepository	repository;
+
+	private ProjectMembership					membership;
+
+
+	@Override
+	public void load() {
+		int id;
+
+		id = super.getRequest().getData("id", int.class);
+		this.membership = this.repository.findMembershipById(id);
+	}
+
+	@Override
+	public void authorise() {
+		boolean status;
+
+		status = this.membership != null && this.membership.getProject().getManager().isPrincipal();
+		super.setAuthorised(status);
+	}
+
+	@Override
+	public void unbind() {
+		// memberName and memberType are @Transient computed getters on ProjectMembership
+		super.unbindObject(this.membership, "memberName", "memberType");
+		super.getResponse().addGlobal("projectId", this.membership.getProject().getId());
+		super.getResponse().addGlobal("draftMode", this.membership.getProject().isDraftMode());
+	}
+}

--- a/src/main/resources/WEB-INF/views/manager/project-membership/form.jsp
+++ b/src/main/resources/WEB-INF/views/manager/project-membership/form.jsp
@@ -1,0 +1,18 @@
+<%@page%>
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:form>
+	<jstl:choose>
+		<jstl:when test="${_command == 'create'}">
+			<acme:form-select code="manager.project-membership.form.label.inventor"      path="inventor"      choices="${inventorChoices}"/>
+			<acme:form-select code="manager.project-membership.form.label.spokesperson"   path="spokesperson"  choices="${spokespersonChoices}"/>
+			<acme:form-select code="manager.project-membership.form.label.fundraiser"     path="fundraiser"    choices="${fundraiserChoices}"/>
+			<acme:submit code="manager.project-membership.form.button.create" action="/manager/project-membership/create?projectId=${projectId}"/>
+		</jstl:when>
+		<jstl:when test="${_command == 'show'}">
+			<acme:form-textbox code="manager.project-membership.form.label.memberName" path="memberName" readonly="true"/>
+			<acme:form-textbox code="manager.project-membership.form.label.memberType" path="memberType" readonly="true"/>
+		</jstl:when>
+	</jstl:choose>
+</acme:form>

--- a/src/main/resources/WEB-INF/views/manager/project-membership/list.jsp
+++ b/src/main/resources/WEB-INF/views/manager/project-membership/list.jsp
@@ -1,0 +1,12 @@
+<%@page%>
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:list>
+	<acme:list-column code="manager.project-membership.list.label.memberName" path="memberName" width="50%"/>
+	<acme:list-column code="manager.project-membership.list.label.memberType" path="memberType" width="50%"/>
+</acme:list>
+
+<jstl:if test="${showCreate == true}">
+	<acme:button code="manager.project-membership.list.button.create" action="/manager/project-membership/create?projectId=${projectId}"/>
+</jstl:if>

--- a/src/main/resources/WEB-INF/views/manager/project-membership/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/manager/project-membership/messages-en.i18n
@@ -1,0 +1,19 @@
+manager.project-membership.form.title = Project Member details
+manager.project-membership.list.title = Project Members
+
+manager.project-membership.form.label.inventor      = Inventor:
+manager.project-membership.form.label.spokesperson   = Spokesperson:
+manager.project-membership.form.label.fundraiser     = Fundraiser:
+manager.project-membership.form.label.memberName     = Member name:
+manager.project-membership.form.label.memberType     = Member type:
+
+manager.project-membership.form.button.create = Add member
+
+manager.project-membership.form.error.no-member  = You must select at least one member.
+manager.project-membership.form.error.duplicate   = This member is already part of the project.
+manager.project-membership.form.error.multiple-roles = You must select exactly one role (Inventor, Spokesperson, or Fundraiser).
+
+manager.project-membership.list.label.memberName = Member Name
+manager.project-membership.list.label.memberType = Type
+
+manager.project-membership.list.button.create = Add member

--- a/src/main/resources/WEB-INF/views/manager/project-membership/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/manager/project-membership/messages-es.i18n
@@ -1,0 +1,19 @@
+manager.project-membership.form.title = Project Member details
+manager.project-membership.list.title = Project Members
+
+manager.project-membership.form.label.inventor      = Inventor:
+manager.project-membership.form.label.spokesperson   = Spokesperson:
+manager.project-membership.form.label.fundraiser     = Fundraiser:
+manager.project-membership.form.label.memberName     = Member name:
+manager.project-membership.form.label.memberType     = Member type:
+
+manager.project-membership.form.button.create = Add member
+
+manager.project-membership.form.error.no-member  = You must select at least one member.
+manager.project-membership.form.error.duplicate   = This member is already part of the project.
+manager.project-membership.form.error.multiple-roles = You must select exactly one role (Inventor, Spokesperson, or Fundraiser).
+
+manager.project-membership.list.label.memberName = Member Name
+manager.project-membership.list.label.memberType = Type
+
+manager.project-membership.list.button.create = Add member


### PR DESCRIPTION
Implement ProjectMembership management: list users who are not yet project members and allow managers to add inventors, spokespeople and fundraisers to projects. Do not include update, remove or ban behaviour.